### PR TITLE
form helpers in v0.9.5

### DIFF
--- a/lib/active_enum/extensions.rb
+++ b/lib/active_enum/extensions.rb
@@ -51,6 +51,7 @@ module ActiveEnum
       end
 
       def active_enum_for(attribute)
+        self.enumerated_attributes ||= {}
         enumerated_attributes[attribute.to_sym]
       end
 

--- a/spec/active_enum/extensions_spec.rb
+++ b/spec/active_enum/extensions_spec.rb
@@ -12,6 +12,9 @@ describe ActiveEnum::Extensions do
     value :id => 2, :name => 'Maybe'
   end
 
+  class Company < ActiveRecord::Base
+  end
+
   it 'should add class :enumerate method to ActiveRecord' do
     ActiveRecord::Base.should respond_to(:enumerate)
   end
@@ -52,6 +55,14 @@ describe ActiveEnum::Extensions do
     expect {
       Person.enumerate :first_name
     }.should raise_error(ActiveEnum::EnumNotFound)
+  end
+
+  it '.active_enum_for should return nil for unknown enumeration' do
+    Person.active_enum_for(:not_found).should be_nil
+  end
+
+  it '.active_enum_for should return nil for unenumerated AR models' do
+    Company.active_enum_for(:id).should be_nil
   end
 
   context "attribute" do


### PR DESCRIPTION
When I updated from v0.9.1 to v0.9.5 I noticed some errors. In one of my views I have

``` erb
<% for item in [:mon, :tue, :wed, :thu, :fri, :sat, :sun] %>
    <span>
        <%= f.check_box item %>
        <%= f.label item %>
    </span>
<% end %>
```

Before the update there were no problems but after the update the row `<%= f.label item %>` is giving me the following error

```
You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.[]
```

The error only occurs I use the simple form helper. The trace gives me

```
active_enum (0.9.5) lib/active_enum/extensions.rb:54:in `active_enum_for'
active_enum (0.9.5) lib/active_enum/form_helpers/simple_form.rb:9:in `default_input_type_with_active_enum'
simple_form (1.4.2) lib/simple_form/form_builder.rb:272:in `label'
```
