### PR TITLE
Make EnumInput available to formtastic-bootstrap form builder.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -206,6 +206,10 @@ Formtastic <2:
 
   require 'active_enum/form_helpers/formtastic'
 
+Formtastic Bootstrap:
+
+  require 'active_enum/form_helpers/formtastic2_bootstrap'
+
 Or, SimpleForm:
 
   require 'active_enum/form_helpers/simple_form'

--- a/lib/active_enum/form_helpers/formtastic2_bootstrap.rb
+++ b/lib/active_enum/form_helpers/formtastic2_bootstrap.rb
@@ -1,0 +1,16 @@
+require File.join(File.dirname(__FILE__), 'formtastic2')
+
+module FormtasticBootstrap
+  module Inputs
+    class EnumInput < FormtasticBootstrap::Inputs::SelectInput
+
+      def raw_collection
+        @raw_collection ||= begin
+          raise "Attribute '#{@method}' has no enum class" unless enum = @object.class.active_enum_for(@method)
+          enum.to_select
+        end
+      end
+
+    end
+  end
+end

--- a/lib/generators/active_enum/templates/config.rb
+++ b/lib/generators/active_enum/templates/config.rb
@@ -1,6 +1,7 @@
 # Form helper integration
 # require 'active_enum/form_helpers/formtastic'  # for Formtastic <2
 # require 'active_enum/form_helpers/formtastic2' # for Formtastic 2.x
+# require 'active_enum/form_helpers/formtastic2_bootstrap' # for Formtastic 2.x + Formtastic-Bootstrap
 
 ActiveEnum.setup do |config|
 


### PR DESCRIPTION
Hi there,

formtastic-bootstrap uses its custom namespace `FormtasticBootstrap`.
To make active_enum working with formtastic-bootstrap the `EnumInput` has to be defined in the module `FormtasticBootstrap::Inputs` and inherit from `FormtasticBootstrap::Inputs::SelectInput`.

fixes https://github.com/adzap/active_enum/issues/24 