### PR TITLE
Fixed boolean check methods when using 'config.use_name_as_value = true'...

### DIFF
--- a/lib/active_enum/extensions.rb
+++ b/lib/active_enum/extensions.rb
@@ -127,7 +127,7 @@ module ActiveEnum
         class_eval <<-DEF
           def #{attribute}?(arg=nil)
             if arg
-              self.#{attribute} == self.class.active_enum_for(:#{attribute})[arg]
+                self.#{attribute}(:id) == self.class.active_enum_for(:#{attribute})[arg]
             else
               super()
             end

--- a/spec/active_enum/extensions_spec.rb
+++ b/spec/active_enum/extensions_spec.rb
@@ -198,6 +198,10 @@ describe ActiveEnum::Extensions do
         person.sex.should == 'Male'
       end
 
+      it 'should return true for boolean match' do
+        person.sex?(:male).should be_true
+      end
+
       after(:all) { ActiveEnum.use_name_as_value = false }
     end
 


### PR DESCRIPTION
fixes https://github.com/adzap/active_enum/issues/26
