### PR TITLE
Adding a Rails 3.0.0 line to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 env:
+  - "RAILS_VERSION=3.0.0"
   - "RAILS_VERSION=3.1.0"
   - "RAILS_VERSION=3.2.0"
   - "RAILS_VERSION=4.0.0"


### PR DESCRIPTION
Since the gem does support the 3.0.x branch.
