### PR TITLE
Updated scope syntax to remove deprecation warning in Rails 4

### DIFF
--- a/lib/active_enum/acts_as_enum.rb
+++ b/lib/active_enum/acts_as_enum.rb
@@ -7,9 +7,9 @@ module ActiveEnum
         extend ClassMethods
         class_attribute :active_enum_options
         self.active_enum_options = options.reverse_merge(:name_column => 'name')
-        scope :enum_values, select("#{primary_key}, #{active_enum_options[:name_column]}").
-                            where(active_enum_options[:conditions]).
-                            order("#{primary_key} #{active_enum_options[:order]}")
+        scope :enum_values, -> { select("#{primary_key}, #{active_enum_options[:name_column]}").
+                                 where(active_enum_options[:conditions]).
+                                 order("#{primary_key} #{active_enum_options[:order]}") }
       end
 
     end


### PR DESCRIPTION
Just a quick update to the Rails 4 scope syntax