### PR TITLE
Allow to specify custom storage for enum class

### DIFF
--- a/lib/active_enum.rb
+++ b/lib/active_enum.rb
@@ -47,7 +47,11 @@ module ActiveEnum
   end
 
   def self.storage_class
-    @@storage_class ||= "ActiveEnum::Storage::#{storage.to_s.classify}Store".constantize
+    @@storage_class ||= get_storage_class(storage)
+  end
+  
+  def self.get_storage_class(storage)
+    "ActiveEnum::Storage::#{storage.to_s.classify}Store".constantize
   end
 
   private

--- a/lib/active_enum/base.rb
+++ b/lib/active_enum/base.rb
@@ -78,6 +78,10 @@ module ActiveEnum
         end
         row[2] || {} if row
       end
+      
+      def storage=(storage)
+        @store = ActiveEnum.get_storage_class(storage).new(self, @order || :asc, ActiveEnum.storage_options)
+      end
 
       private
 

--- a/lib/active_enum/extensions.rb
+++ b/lib/active_enum/extensions.rb
@@ -33,7 +33,7 @@ module ActiveEnum
         attributes.each do |attribute|
           begin
             if block_given?
-              enum = define_implicit_enum_class_for_attribute(attribute, block)
+              enum = define_implicit_enum_class_for_attribute(attribute, options.slice(:storage), block)
             else
               enum = options[:with] || attribute.to_s.camelize.constantize
             end
@@ -60,10 +60,11 @@ module ActiveEnum
         define_active_enum_question_method(attribute)
       end
 
-      def define_implicit_enum_class_for_attribute(attribute, block)
+      def define_implicit_enum_class_for_attribute(attribute, options = {}, block)
         enum_class_name = "#{name}::#{attribute.to_s.camelize}"
         eval("class #{enum_class_name} < ActiveEnum::Base; end")
         enum = enum_class_name.constantize
+        enum.storage = options[:storage] if options.key? :storage
         enum.class_eval &block
         enum
       end

--- a/spec/active_enum/extensions_spec.rb
+++ b/spec/active_enum/extensions_spec.rb
@@ -47,7 +47,7 @@ describe ActiveEnum::Extensions do
     end
     Person.active_enum_for(:sex).should == ::Person::Sex
   end
-
+  
   it 'should raise error if implicit enumeration class cannot be found' do
     expect {
       Person.enumerate :first_name
@@ -206,5 +206,33 @@ describe ActiveEnum::Extensions do
     end
 
   end
+  
+  context "with specified storage" do
+    let(:person) { Person.new(:sex => 1) }
 
+    before do
+      @default_locale = I18n.locale
+      I18n.backend.store_translations :en, :active_enum => { :person => { :sex => { 'male' => 'Male', 'female' => 'Female' } } }
+      I18n.locale = :en
+
+      reset_class Person do
+        enumerate :sex, storage: :i18n do
+          value 1 => 'male'
+          value 2 => 'female'
+        end
+      end
+    end
+
+    after do
+      I18n.locale = @default_locale
+    end
+
+    it 'should load the specified storage class instance' do
+      Person.active_enum_for(:sex).send(:store).should be_instance_of(ActiveEnum::Storage::I18nStore)
+    end
+
+    it 'should return text name value for attribute' do
+      person.sex(:name).should == 'Male'
+    end
+  end
 end


### PR DESCRIPTION
Allow to specify custom storage for enum class via:
- `self.storage=` method inside enum classes:
  
  ``` ruby
  class Sex < ActiveEnum::Base
    self.storage = :i18n
  end
  ```
- `:storage` option for `enumerate` method with block:
  
  ``` ruby
  class Person < ActiveRecord::Base
    enumerate :sex, storage: :i18n do
      # ...
    end
  end
  ```
