### PR TITLE
Adding the ability to write enums as strings.

### DIFF
--- a/lib/active_enum/extensions.rb
+++ b/lib/active_enum/extensions.rb
@@ -105,11 +105,12 @@ module ActiveEnum
       # Examples:
       #   user.sex = 1
       #   user.sex = :male
+      #   user.sex = 'Male'
       #
       def define_active_enum_write_method(attribute)
         class_eval <<-DEF
           def #{attribute}=(arg)
-            if arg.is_a?(Symbol)
+            if arg.is_a?(Symbol) || arg.is_a?(String)
               super self.class.active_enum_for(:#{attribute})[arg]
             else
               super arg

--- a/spec/active_enum/extensions_spec.rb
+++ b/spec/active_enum/extensions_spec.rb
@@ -182,6 +182,11 @@ describe ActiveEnum::Extensions do
         person.sex.should == nil
       end
 
+      it 'should store id value when valid enum name' do
+        person.sex = 'Female'
+        person.sex.should == 2
+      end
+
     end
 
     context "with value as enum name" do
@@ -196,6 +201,11 @@ describe ActiveEnum::Extensions do
 
       it 'should return text name value for attribute' do
         person.sex.should == 'Male'
+      end
+
+      it 'should store value when valid enum name' do
+        person.sex = 'Female'
+        person.sex.should == 'Female'
       end
 
       it 'should return true for boolean match' do


### PR DESCRIPTION
Firstly, thank you for writing this module. It has improved the performance of my employer's application greatly.

We generally expect that a setter can accept a value from its own getter. However, when using ActiveEnum.use_name_as_value = true, enums must be written as either symbols or integers. Consider the following situation:

```
person = Person.new(sex: :male)
puts person.sex # "Male"
person.sex = person.sex
puts person.sex # nil
```

This behavior is counter-intuitive: a leaky abstraction. Particularly, it causes issues saving form data. This commit makes an enum accept strings, symbols and integers, fixing the leaky abstraction.

Take care and thank you for reviewing this request.
